### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/app/src/main/java/org/kore/kolabnotes/android/fragment/AttachmentFragment.java
+++ b/app/src/main/java/org/kore/kolabnotes/android/fragment/AttachmentFragment.java
@@ -205,6 +205,9 @@ public class AttachmentFragment extends Fragment {
                 } else {
                     fileName = path.substring(path.lastIndexOf("/") + 1);
                 }
+				if (cursor != null) {
+					cursor.close();
+				}
 
                 String mimeType = contentResolver.getType(uri);
 

--- a/app/src/main/java/org/kore/kolabnotes/android/fragment/OverviewFragment.java
+++ b/app/src/main/java/org/kore/kolabnotes/android/fragment/OverviewFragment.java
@@ -1206,6 +1206,9 @@ public class OverviewFragment extends Fragment implements /*NoteAdapter.NoteSele
 
                         notebookName = withouFileEnding(path.substring(path.lastIndexOf("/") + 1));
                     }
+					if (cursor != null) {
+						cursor.close();
+					}
 
                     InputStream inputStream = getActivity().getContentResolver().openInputStream(uri);
 
@@ -1243,6 +1246,9 @@ public class OverviewFragment extends Fragment implements /*NoteAdapter.NoteSele
 
                     notebookName = withouFileEnding(path.substring(path.lastIndexOf("/") + 1));
                 }
+				if (cursor != null) {
+					cursor.close();
+				}
 
                 ParcelFileDescriptor pfd = getActivity().getContentResolver().openFileDescriptor(uri, "w");
                 FileOutputStream fileOutputStream = new FileOutputStream(pfd.getFileDescriptor());

--- a/app/src/main/java/org/kore/kolabnotes/android/repository/NotebookContentResolver.java
+++ b/app/src/main/java/org/kore/kolabnotes/android/repository/NotebookContentResolver.java
@@ -25,12 +25,18 @@ public final class NotebookContentResolver {
         Cursor cursor = context.getContentResolver().query(uri, new String[0], null, null, null);
 
         if(cursor == null){
-            return Collections.emptyList();
+            if (cursor != null) {
+				cursor.close();
+			}
+			return Collections.emptyList();
         }
         
         while(cursor.moveToNext()){
             //TODO was machen
         }
+		if (cursor != null) {
+			cursor.close();
+		}
         return null;
     }
 

--- a/app/src/main/java/yuku/ambilwarna/widget/AmbilWarnaPreference.java
+++ b/app/src/main/java/yuku/ambilwarna/widget/AmbilWarnaPreference.java
@@ -21,6 +21,9 @@ public class AmbilWarnaPreference extends Preference {
 
 		final TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.AmbilWarnaPreference);
 		supportsAlpha = ta.getBoolean(R.styleable.AmbilWarnaPreference_supportsAlpha, false);
+		if (ta != null) {
+			ta.recycle();
+		}
 
 		setWidgetLayoutResource(R.layout.ambilwarna_pref_widget);
 	}


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis